### PR TITLE
feat: allow requesting custom resources in the searchitems request

### DIFF
--- a/nodes/AmazonPA/AmazonPA.node.ts
+++ b/nodes/AmazonPA/AmazonPA.node.ts
@@ -84,6 +84,204 @@ export class AmazonPA implements INodeType {
                 description: 'Keywords to search for items on Amazon',
             },
             {
+              displayName: 'Resources (for Search Items)',
+              name: 'resources',
+              type: 'multiOptions',
+              displayOptions: {
+                show: {
+                  operation: ['searchItems'],
+                },
+              },
+              options: [
+                {
+                  name: 'BrowseNodeInfo.BrowseNodes',
+                  value: 'BrowseNodeInfo.BrowseNodes',
+                },
+                {
+                  name: 'BrowseNodeInfo.BrowseNodes.Ancestor',
+                  value: 'BrowseNodeInfo.BrowseNodes.Ancestor',
+                },
+                {
+                  name: 'BrowseNodeInfo.BrowseNodes.SalesRank',
+                  value: 'BrowseNodeInfo.BrowseNodes.SalesRank',
+                },
+                {
+                  name: 'BrowseNodeInfo.WebsiteSalesRank',
+                  value: 'BrowseNodeInfo.WebsiteSalesRank',
+                },
+                {
+                  name: 'CustomerReviews.Count',
+                  value: 'CustomerReviews.Count',
+                },
+                {
+                  name: 'CustomerReviews.StarRating',
+                  value: 'CustomerReviews.StarRating',
+                },
+                {
+                  name: 'Images.Primary.Small',
+                  value: 'Images.Primary.Small',
+                },
+                {
+                  name: 'Images.Primary.Medium',
+                  value: 'Images.Primary.Medium',
+                },
+                {
+                  name: 'Images.Primary.Large',
+                  value: 'Images.Primary.Large',
+                },
+                {
+                  name: 'Images.Variants.Small',
+                  value: 'Images.Variants.Small',
+                },
+                {
+                  name: 'Images.Variants.Medium',
+                  value: 'Images.Variants.Medium',
+                },
+                {
+                  name: 'Images.Variants.Large',
+                  value: 'Images.Variants.Large',
+                },
+                {
+                  name: 'ItemInfo.ByLineInfo',
+                  value: 'ItemInfo.ByLineInfo',
+                },
+                {
+                  name: 'ItemInfo.ContentInfo',
+                  value: 'ItemInfo.ContentInfo',
+                },
+                {
+                  name: 'ItemInfo.ContentRating',
+                  value: 'ItemInfo.ContentRating',
+                },
+                {
+                  name: 'ItemInfo.Classifications',
+                  value: 'ItemInfo.Classifications',
+                },
+                {
+                  name: 'ItemInfo.ExternalIds',
+                  value: 'ItemInfo.ExternalIds',
+                },
+                {
+                  name: 'ItemInfo.Features',
+                  value: 'ItemInfo.Features',
+                },
+                {
+                  name: 'ItemInfo.ManufactureInfo',
+                  value: 'ItemInfo.ManufactureInfo',
+                },
+                {
+                  name: 'ItemInfo.ProductInfo',
+                  value: 'ItemInfo.ProductInfo',
+                },
+                {
+                  name: 'ItemInfo.TechnicalInfo',
+                  value: 'ItemInfo.TechnicalInfo',
+                },
+                {
+                  name: 'ItemInfo.Title',
+                  value: 'ItemInfo.Title',
+                },
+                {
+                  name: 'ItemInfo.TradeInInfo',
+                  value: 'ItemInfo.TradeInInfo',
+                },
+                {
+                  name: 'Offers.Listings.Availability.MaxOrderQuantity',
+                  value: 'Offers.Listings.Availability.MaxOrderQuantity',
+                },
+                {
+                  name: 'Offers.Listings.Availability.Message',
+                  value: 'Offers.Listings.Availability.Message',
+                },
+                {
+                  name: 'Offers.Listings.Availability.MinOrderQuantity',
+                  value: 'Offers.Listings.Availability.MinOrderQuantity',
+                },
+                {
+                  name: 'Offers.Listings.Availability.Type',
+                  value: 'Offers.Listings.Availability.Type',
+                },
+                {
+                  name: 'Offers.Listings.Condition',
+                  value: 'Offers.Listings.Condition',
+                },
+                {
+                  name: 'Offers.Listings.Condition.ConditionNote',
+                  value: 'Offers.Listings.Condition.ConditionNote',
+                },
+                {
+                  name: 'Offers.Listings.Condition.SubCondition',
+                  value: 'Offers.Listings.Condition.SubCondition',
+                },
+                {
+                  name: 'Offers.Listings.DeliveryInfo.IsAmazonFulfilled',
+                  value: 'Offers.Listings.DeliveryInfo.IsAmazonFulfilled',
+                },
+                {
+                  name: 'Offers.Listings.DeliveryInfo.IsFreeShippingEligible',
+                  value: 'Offers.Listings.DeliveryInfo.IsFreeShippingEligible',
+                },
+                {
+                  name: 'Offers.Listings.DeliveryInfo.IsPrimeEligible',
+                  value: 'Offers.Listings.DeliveryInfo.IsPrimeEligible',
+                },
+                {
+                  name: 'Offers.Listings.IsBuyBoxWinner',
+                  value: 'Offers.Listings.IsBuyBoxWinner',
+                },
+                {
+                  name: 'Offers.Listings.LoyaltyPoints.Points',
+                  value: 'Offers.Listings.LoyaltyPoints.Points',
+                },
+                {
+                  name: 'Offers.Listings.MerchantInfo',
+                  value: 'Offers.Listings.MerchantInfo',
+                },
+                {
+                  name: 'Offers.Listings.Price',
+                  value: 'Offers.Listings.Price',
+                },
+                {
+                  name: 'Offers.Listings.ProgramEligibility.IsPrimeExclusive',
+                  value: 'Offers.Listings.ProgramEligibility.IsPrimeExclusive',
+                },
+                {
+                  name: 'Offers.Listings.ProgramEligibility.IsPrimePantry',
+                  value: 'Offers.Listings.ProgramEligibility.IsPrimePantry',
+                },
+                {
+                  name: 'Offers.Listings.Promotions',
+                  value: 'Offers.Listings.Promotions',
+                },
+                {
+                  name: 'Offers.Listings.SavingBasis',
+                  value: 'Offers.Listings.SavingBasis',
+                },
+                {
+                  name: 'Offers.Summaries.HighestPrice',
+                  value: 'Offers.Summaries.HighestPrice',
+                },
+                {
+                  name: 'Offers.Summaries.LowestPrice',
+                  value: 'Offers.Summaries.LowestPrice',
+                },
+                {
+                  name: 'Offers.Summaries.OfferCount',
+                  value: 'Offers.Summaries.OfferCount',
+                },
+                {
+                  name: 'ParentASIN',
+                  value: 'ParentASIN',
+                },
+                {
+                  name: 'SearchRefinements',
+                  value: 'SearchRefinements',
+                }
+              ],
+              default: '',
+              description: '',
+            },
+            {
                 displayName: 'Browse Node IDs (for Get Browse Nodes)',
                 name: 'browseNodeIds',
                 type: 'string',
@@ -104,10 +302,10 @@ export class AmazonPA implements INodeType {
 
         // Retrieve credentials
         const credentials = await this.getCredentials('amazonPaApi');
-        
+
         // Get partnerTag either from the input or from the credentials
         const partnerTag = this.getNodeParameter('partnerTag', 0, '') as string || credentials.partnerTag;
-        
+
         // Ensure PartnerTag exists
         if (!partnerTag) {
             throw new Error('PartnerTag is required but was not provided in both the request and credentials.');
@@ -138,9 +336,9 @@ export class AmazonPA implements INodeType {
                     } else {
                         throw new Error('Item IDs are required but were not provided.');
                     }
-                    console.log('Common Parameters:', commonParameters); 
+                    console.log('Common Parameters:', commonParameters);
                     console.log('Request Parameters for GetItems:', requestParameters);
-                    
+
                     responseData = await amazonPaapi.GetItems(commonParameters, requestParameters);
                     try {
                         console.log('responseData: ', responseData.body)
@@ -151,6 +349,8 @@ export class AmazonPA implements INodeType {
                     // Handling Search Items request
                     const keywords = this.getNodeParameter('keywords', i) as string;
                     requestParameters.Keywords = keywords;
+                    const resources = this.getNodeParameter('resources', i) as string[];
+                    requestParameters.Resources = resources;
                     responseData = await amazonPaapi.SearchItems(commonParameters, requestParameters);
                 } else if (operation === 'getBrowseNodes') {
                     // Handling Get Browse Nodes request


### PR DESCRIPTION
Using custom resources on the request allow to retrieve other information from the products, like the product image.

Docs: https://webservices.amazon.de/paapi5/documentation/get-items.html#resources-parameter

Fixes #3
Fixes #2